### PR TITLE
Add Set Picking Type button

### DIFF
--- a/static/src/app/screens/product_screen/set_picking_type_button/set_picking_type_button.js
+++ b/static/src/app/screens/product_screen/set_picking_type_button/set_picking_type_button.js
@@ -1,0 +1,64 @@
+/** @odoo-module **/
+
+import {_t} from "@web/core/l10n/translation";
+import {ProductScreen} from "@point_of_sale/app/screens/product_screen/product_screen";
+import {useService} from "@web/core/utils/hooks";
+import {SelectionPopup} from "@point_of_sale/app/utils/input_popups/selection_popup";
+import {Component} from "@odoo/owl";
+import {usePos} from "@point_of_sale/app/store/pos_hook";
+
+export class ButtonSetPickingType extends Component {
+    static template = "pos_retail.ButtonSetPickingType";
+
+    setup() {
+        super.setup();
+        this.pos = usePos();
+        this.popup = useService("popup");
+    }
+
+    get currentPickingTypeName() {
+        if (this.pos.picking_type) {
+            return this.pos.picking_type.display_name || this.pos.picking_type.name;
+        }
+        return _t('Set Operation Type');
+    }
+
+    async click() {
+        if (!this.pos.config.multi_stock_operation_type_ids || !this.pos.stock_picking_type_by_id) {
+            return;
+        }
+        const list = [];
+        this.pos.config.multi_stock_operation_type_ids.forEach((id) => {
+            const pt = this.pos.stock_picking_type_by_id[id];
+            if (pt) {
+                list.push({
+                    id: pt.id,
+                    label: pt.display_name || pt.name,
+                    isSelected: this.pos.picking_type && this.pos.picking_type.id === pt.id,
+                    item: pt,
+                });
+            }
+        });
+        if (!list.length) return;
+        const { confirmed, payload } = await this.popup.add(SelectionPopup, {
+            title: _t('Select Stock Operation Type'),
+            list,
+        });
+        if (confirmed) {
+            this.pos.picking_type = payload;
+            if (payload.default_location_src_id) {
+                this.pos.default_location_src_id = payload.default_location_src_id[0];
+                if (this.pos.stock_location_by_id) {
+                    this.pos.self_stock_location = this.pos.stock_location_by_id[payload.default_location_src_id[0]];
+                }
+            }
+        }
+    }
+}
+
+ProductScreen.addControlButton({
+    component: ButtonSetPickingType,
+    condition: function () {
+        return this.env.pos.config.multi_stock_operation_type;
+    },
+});

--- a/static/src/app/screens/product_screen/set_picking_type_button/set_picking_type_button.xml
+++ b/static/src/app/screens/product_screen/set_picking_type_button/set_picking_type_button.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+
+    <t t-name="pos_retail.ButtonSetPickingType">
+        <button class="control-button o_pricelist_button btn btn-light rounded-0 fw-bolder"
+                t-on-click="() => this.click()">
+            <i class="fa fa-exchange me-1" role="img" aria-label="Set Operation Type" title="Set Operation Type" />
+            <span t-out="currentPickingTypeName"/>
+        </button>
+    </t>
+
+</templates>

--- a/static/src/app/store/pos_store.js
+++ b/static/src/app/store/pos_store.js
@@ -32,6 +32,14 @@ patch(PosStore.prototype, {
     async _processData(loadedData) {
         const config = loadedData["pos.config"]
         const res = await super._processData(...arguments);
+        if (config.multi_stock_operation_type) {
+            this.stock_picking_type_by_id = {};
+            if (loadedData["stock.picking.type"]) {
+                loadedData["stock.picking.type"].forEach(pt => {
+                    this.stock_picking_type_by_id[pt.id] = pt;
+                });
+            }
+        }
         if (config.display_onhand) {
             this.stock_location_ids = [loadedData["stock.picking.type"]['default_location_src_id'][0]]
             this.default_location_src_id = loadedData["stock.picking.type"]['default_location_src_id'][0]


### PR DESCRIPTION
## Summary
- add a POS button to select the Stock Operation Type on the product screen
- store available picking types in the POS store when multi-picking is enabled

## Testing
- `python -m py_compile $(git ls-files '*.py')` *(fails: SyntaxError in scripts/partner_data.py)*

------
https://chatgpt.com/codex/tasks/task_e_685ca519410483298544173d3ca74c66